### PR TITLE
Add target Ruby version

### DIFF
--- a/.rubocop_default.yml
+++ b/.rubocop_default.yml
@@ -3,6 +3,7 @@
 ########################################
 
 AllCops:
+  TargetRubyVersion: 2.4.6
   Exclude:
     - 'db/schema.rb'
     - 'node_modules/**/*'


### PR DESCRIPTION
To fix the issue safe navigator operator is not recognized by rubocop

Signed-off-by: Huy Duong <huy.duong@employmenthero.com>