### PR TITLE
Add organization level configs for rubocop v1

### DIFF
--- a/.rubocop-performance_default_v1.yml
+++ b/.rubocop-performance_default_v1.yml
@@ -1,0 +1,8 @@
+########################################
+# EmploymentHero Shared Rubocop Config #
+########################################
+# rubocop-performance ~> 1.11.3
+# https://docs.rubocop.org/rubocop-performance/cops_performance.html
+
+Performance:
+  Severity: warning

--- a/.rubocop-rails_default_v2.yml
+++ b/.rubocop-rails_default_v2.yml
@@ -1,0 +1,11 @@
+########################################
+# EmploymentHero Shared Rubocop Config #
+########################################
+# rubocop-rails ~> 2.10.1
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html
+
+Rails:
+  Severity: warning
+
+Rails/HttpStatus:
+  Enabled: false

--- a/.rubocop_default_v1.yml
+++ b/.rubocop_default_v1.yml
@@ -1,0 +1,299 @@
+########################################
+# EmploymentHero Shared Rubocop Config #
+########################################
+# rubocop ~> 1.15.0
+
+AllCops:
+  Exclude:
+    - 'db/schema.rb'
+    - 'node_modules/**/*'
+    - 'vendor/**/*'
+    - '.git/**/*'
+  EnabledByDefault: false
+  DisabledByDefault: false
+  NewCops: disable
+
+Bundler:
+  Severity: warning
+
+Bundler/OrderedGems:
+  Description: >-
+                 Gems within groups in the Gemfile should be alphabetically sorted.
+  Enabled: false
+  VersionAdded: '0.46'
+  VersionChanged: '0.47'
+  TreatCommentsAsGroupSeparators: true
+  Include:
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
+
+Gemspec:
+  Severity: warning
+
+Layout/ClassStructure:
+  Severity: warning
+  Description: 'Enforces a configured order of definitions within a class body.'
+  StyleGuide: 'https://github.com/rubocop-hq/ruby-style-guide#consistent-classes'
+  Enabled: true
+  VersionAdded: '0.52'
+  Categories:
+    module_inclusion:
+      - include
+      - prepend
+      - extend
+  ExpectedOrder:
+      - module_inclusion
+      - constants
+      - public_class_methods
+      - initializer
+      - public_methods
+      - protected_methods
+      - private_methods
+
+Metrics:
+  Severity: warning
+
+Metrics/BlockLength:
+  Description: 'Avoid long blocks with many lines.'
+  Enabled: true
+  VersionAdded: '0.44'
+  VersionChanged: '0.58'
+  CountComments: false  # count full line comments?
+  Max: 25
+  IgnoredMethods:
+    # By default, exclude the `#refine` method, as it tends to have larger
+    # associated blocks.
+    - configure
+    - included
+    - refine
+    - transaction
+    # rake methods
+    - namespace
+    - task
+    # rails methods
+    - create_table
+    - update_table
+    - setup
+    # grape api methods
+    - helpers
+    - group
+    - resource
+    - resources
+    - segment
+    - get
+    - post
+    - put
+    - patch
+    - delete
+    - route_param
+    # rspec methods
+    - after
+    - let
+    - let!
+    - before
+    - context
+    - describe
+    - describe_api
+    - feature
+    - shared_context
+    - shared_examples
+    - shared_examples_for
+    # factory_bot methods
+    - define
+    - factory
+    # cucumber methods
+    - scenario
+    - then
+    - when
+    - within
+    # pundit spec methods
+    - permissions
+    # Benchmark methods
+    - measure
+
+Metrics/ClassLength:
+  Description: 'Avoid classes longer than 200 lines of code.'
+  Enabled: true
+  VersionAdded: '0.25'
+  CountComments: false  # count full line comments?
+  Max: 200
+
+# Avoid complex methods.
+Metrics/CyclomaticComplexity:
+  Description: >-
+                 A complexity metric that is strongly correlated to the number
+                 of test cases needed to validate a method.
+  Enabled: true
+  VersionAdded: '0.25'
+  Max: 10
+
+Layout/LineLength:
+  Description: 'Limit lines to 120 characters.'
+  StyleGuide: '#80-character-limits'
+  Enabled: true
+  VersionAdded: '0.25'
+  VersionChanged: '0.46'
+  Max: 120
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
+  # directives like '# rubocop: enable ...' when calculating a line's length.
+  IgnoreCopDirectives: true
+  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
+  # elements. Strings will be converted to Regexp objects. A line that matches
+  # any regular expression listed in this option will be ignored by LineLength.
+  IgnoredPatterns: []
+
+Metrics/MethodLength:
+  Description: 'Avoid methods longer than 15 lines of code.'
+  StyleGuide: '#short-methods'
+  Enabled: true
+  VersionAdded: '0.25'
+  VersionChanged: '0.59.2'
+  CountComments: false  # count full line comments?
+  Max: 15
+  IgnoredMethods: []
+
+Metrics/ModuleLength:
+  Description: 'Avoid modules longer than 200 lines of code.'
+  Enabled: true
+  VersionAdded: '0.31'
+  CountComments: false  # count full line comments?
+  Max: 200
+
+Metrics/PerceivedComplexity:
+  Description: >-
+                 A complexity metric geared towards measuring complexity for a
+                 human reader.
+  Enabled: true
+  VersionAdded: '0.25'
+  Max: 10
+
+Security:
+  Severity: warning
+
+Style/Alias:
+  Description: 'Use alias instead of alias_method.'
+  StyleGuide: '#alias-method'
+  Enabled: false
+  VersionAdded: '0.9'
+  VersionChanged: '0.36'
+  EnforcedStyle: prefer_alias
+  SupportedStyles:
+    - prefer_alias
+    - prefer_alias_method
+
+Style/AndOr:
+  Severity: true
+  Description: 'Use &&/|| instead of and/or.'
+  StyleGuide: '#no-and-or-or'
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.25'
+  # Whether `and` and `or` are banned only in conditionals (conditionals)
+  # or completely (always).
+  EnforcedStyle: conditionals
+  SupportedStyles:
+    - always
+    - conditionals
+
+Style/BlockDelimiters:
+  Severity: warning
+  Description: >-
+                Avoid using {...} for multi-line blocks (multiline chaining is
+                always ugly).
+                Prefer {...} over do...end for single-line blocks.
+  StyleGuide: '#single-line-blocks'
+  Enabled: true
+  VersionAdded: '0.30'
+  VersionChanged: '0.35'
+  EnforcedStyle: braces_for_chaining
+  SupportedStyles:
+    # The `line_count_based` style enforces braces around single line blocks and
+    # do..end around multi-line blocks.
+    - line_count_based
+    # The `semantic` style enforces braces around functional blocks, where the
+    # primary purpose of the block is to return a value and do..end for
+    # procedural blocks, where the primary purpose of the block is its
+    # side-effects.
+    #
+    # This looks at the usage of a block's method to determine its type (e.g. is
+    # the result of a `map` assigned to a variable or passed to another
+    # method) but exceptions are permitted in the `ProceduralMethods`,
+    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    - semantic
+    # The `braces_for_chaining` style enforces braces around single line blocks
+    # and do..end around multi-line blocks, except for multi-line blocks whose
+    # return value is being chained with another method (in which case braces
+    # are enforced).
+    - braces_for_chaining
+  ProceduralMethods:
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
+  FunctionalMethods:
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
+  IgnoredMethods:
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone, e.g.
+    #
+    #   foo = lambda do |x|
+    #     puts "Hello, #{x}"
+    #   end
+    #
+    #   foo = lambda do |x|
+    #     x * 100
+    #   end
+    #
+    # Here, it is impossible to tell from the return value of `lambda` whether
+    # the inner block's return value is significant.
+    - lambda
+    - proc
+    - it
+
+Style/Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: false
+  VersionAdded: '0.9'
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+
+Style/MultipleComparison:
+  Description: >-
+                 Avoid comparing a variable with multiple items in a conditional,
+                 use Array#include? instead.
+  Enabled: false
+  VersionAdded: '0.49'


### PR DESCRIPTION
### What is in the PR
The PR contains some configurations for `rubocop` version 1.x.x to inherit, including new rules renaming and department migrations when rubocop was bumped from version 0.x.x to version 1.x.x.

So far introduced versions are:
- rubocop ~> 1.15.0
- rubocop-rails ~> 2.10.1
- rubocop-performance ~> 1.11.3

### Why 
Rubocop is [stable](https://metaredux.com/posts/2020/10/21/rubocop-1-0.html). It has been half a year rubocop got no [update](https://rubygems.org/gems/rubocop/versions) on version 0. I guess it _is_ EOL as the fast development pace of the gem makes it harder to keep backward compatible. 

Adding configuration first make rooms for upgrading the gem in our application repos, also for https://github.com/Thinkei/rubocop-i18n-coverage to collect missing translation report!

### Follow-up actions
Mainapp will be upgraded first, I am also aware of our internal cops at 
https://github.com/Thinkei/employment-hero/tree/development/cops/eh_cop
will also need to be updated with the following guide [v1_upgrade_notes](https://docs.rubocop.org/rubocop/v1_upgrade_notes.html)
Please open discussion if we need to migrate these cops into internal departments or not, cc @tomta20 
