### PR TITLE
[NO-CARD] Add CLAUDE.md for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a **shared RuboCop configuration repository** for EmploymentHero/ThinkEI. It provides standardized Ruby linting rules to be inherited by other projects across the organization. There is no application code, tests, or CI pipeline — only configuration files.
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `.rubocop_default.yml` | Legacy RuboCop v0.x configuration |
+| `.rubocop_default_v1.yml` | Current RuboCop ~1.15.0 configuration |
+| `.rubocop-rails_default_v2.yml` | RuboCop Rails extension ~2.10.1 |
+| `.rubocop-performance_default_v1.yml` | RuboCop Performance extension ~1.11.3 |
+
+## Key Conventions
+
+- **Line length**: 120 characters max (`Layout/LineLength`)
+- **Method length**: 15 lines max (`Metrics/MethodLength`)
+- **Class/Module length**: 200 lines max
+- **Cyclomatic/Perceived complexity**: 10 max
+- `NewCops: disable` — new cops are opted into explicitly, not auto-enabled
+- Most `Metrics` and `Security` cops are set to `Severity: warning` rather than error
+- `Style/Documentation` is disabled (class/module docs not required)
+
+## How Projects Use These Configs
+
+Other repos inherit these configs via RuboCop's `inherit_from` directive, e.g.:
+```yaml
+inherit_from:
+  - https://raw.githubusercontent.com/ThinkEI/configs/master/.rubocop_default_v1.yml
+```
+
+When updating configs, consider the downstream impact on all projects that inherit from them. Prefer adding new cops as `Enabled: false` or `Severity: warning` initially.


### PR DESCRIPTION
## Why

This repository had no CLAUDE.md, meaning Claude Code instances had no context about the repo's purpose, structure, or conventions when starting a new session.

## Summary

Added a `CLAUDE.md` file that documents the repo's purpose (shared RuboCop config), the config files and their versions, key linting thresholds, and how downstream projects consume these configs.

## Changes proposed in this pull request

- `CLAUDE.md` (new) — adds Claude Code guidance covering repo purpose, config file inventory, key cop settings, and usage pattern; reduces ramp-up time for AI-assisted work in this repo

## Test Evidence

No tests — this is a documentation-only change. Manual verification: open the file and confirm content is accurate against the existing `.rubocop_default_v1.yml`.

## Risk

- **Size**: Minimal (36 lines added, no existing code touched)
- **Type**: Documentation — lowest risk category
- **Test evidence clarity**: No tests needed for a markdown file

🤖 Generated with [Claude Code](https://claude.com/claude-code) | Session: ceca899b-6bec-4928-9276-99a0b708d0ad